### PR TITLE
(SIMP-911) Fix malformed `%changelog` entry

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,3 +33,4 @@ group :development do
   gem 'beaker-rspec', :require => false
   gem 'vagrant-wrapper', :require => false
   gem 'simp-rake-helpers',       :require => false
+end

--- a/build/pupmod-augeasproviders_sysctl.spec
+++ b/build/pupmod-augeasproviders_sysctl.spec
@@ -49,7 +49,7 @@ mkdir -p %{buildroot}/%{prefix}/%{mod_name}
 # Post uninstall stuff
 
 %changelog
-* Thu mar 10 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.1.0-0
+* Thu Mar 10 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.1.0-0
 - Updated to the latest version which adds the :silent option.
 
 * Wed Feb 18 2015 Trevor Vaughan <tvaughan@onyxpoint.com> - 2.0.1-0


### PR DESCRIPTION
The lowercase "m" im "mar" was breaking `build:auto` in CI ISO builds.
This patch corrects it to "Mar".

SIMP-232 #close Changed `mar` to `Mar` in `%changelog`
